### PR TITLE
Feature: add basic tracing for incoming messages processing in GAgents

### DIFF
--- a/src/Aevatar.Core/GAgentAsyncObserver.cs
+++ b/src/Aevatar.Core/GAgentAsyncObserver.cs
@@ -6,25 +6,40 @@ namespace Aevatar.Core;
 public class GAgentAsyncObserver : IAsyncObserver<EventWrapperBase>
 {
     private readonly IEnumerable<EventWrapperBaseAsyncObserver> _observers;
+    private readonly string _grainId;
 
-    public GAgentAsyncObserver(IEnumerable<EventWrapperBaseAsyncObserver> observers)
+    public GAgentAsyncObserver(IEnumerable<EventWrapperBaseAsyncObserver> observers, string grainId)
     {
         _observers = observers;
+        _grainId = grainId;
     }
     
     public async Task OnNextAsync(EventWrapperBase item, StreamSequenceToken? token = null)
     {
         var eventType = (EventBase)item.GetType().GetProperty(nameof(EventWrapper<EventBase>.Event))?.GetValue(item)!;
-        // TODO: Maybe use RuleEngine to optimize this.
-        var matchedObservers = _observers.Where(observer =>
-            observer.ParameterTypeName == eventType.GetType().Name ||
-            observer.ParameterTypeName == nameof(EventWrapperBase) ||
-            observer.MethodName == AevatarGAgentConstants.ForwardEventMethodName ||
-            observer.MethodName == AevatarGAgentConstants.ConfigDefaultMethodName).ToList();
-        foreach (var observer in matchedObservers)
+        
+        using var scope = OpenTelemetryScope.Start(_grainId, eventType, token);
+
+        try
         {
-            await observer.OnNextAsync(item);
+            // TODO: Maybe use RuleEngine to optimize this.
+            var matchedObservers = _observers.Where(observer =>
+                observer.ParameterTypeName == eventType.GetType().Name ||
+                observer.ParameterTypeName == nameof(EventWrapperBase) ||
+                observer.MethodName == AevatarGAgentConstants.ForwardEventMethodName ||
+                observer.MethodName == AevatarGAgentConstants.ConfigDefaultMethodName).ToList();
+            foreach (var observer in matchedObservers)
+            {
+                // TODO: add tracing for individual observer
+                await observer.OnNextAsync(item);
+            }            
         }
+        catch (Exception ex)
+        {
+            scope.RecordException(ex);
+            throw;
+        }
+
     }
 
     public async Task OnCompletedAsync()

--- a/src/Aevatar.Core/GAgentBase.cs
+++ b/src/Aevatar.Core/GAgentBase.cs
@@ -306,7 +306,7 @@ public abstract partial class
         {
             var streamOfThisGAgent = GetEventBaseStream(this.GetGrainId());
             var handles = await streamOfThisGAgent.GetAllSubscriptionHandles();
-            var asyncObserver = new GAgentAsyncObserver(_observers);
+            var asyncObserver = new GAgentAsyncObserver(_observers, this.GetGrainId().ToString());
             if (handles.Count > 0)
             {
                 foreach (var handle in handles)

--- a/src/Aevatar.Core/Observability/OpenTelemetryScope.cs
+++ b/src/Aevatar.Core/Observability/OpenTelemetryScope.cs
@@ -1,0 +1,58 @@
+using Aevatar.Core.Abstractions;
+
+namespace Aevatar.Core;
+
+using System.Diagnostics;
+using Orleans.Streams;
+
+internal class OpenTelemetryScope : IDisposable
+{
+    private static readonly ActivitySource ActivitySource = new ActivitySource("Aevatar.Messaging");
+
+    private readonly string _grainId;
+
+    private Activity _activity;
+
+    public static OpenTelemetryScope Start(string grainId, EventBase? @event, StreamSequenceToken? token = null)
+    {
+        var obj = new OpenTelemetryScope(grainId);
+        obj.StartProcessing(@event, token);
+        return obj;
+    }
+
+    private OpenTelemetryScope(string grainId)
+    {
+        _grainId = grainId;
+    }
+
+    private void StartProcessing(EventBase? @event, StreamSequenceToken? token = null)
+    {
+        var eventTypeName = @event?.GetType().FullName ?? "UnknownEvent";
+        _activity = ActivitySource.StartActivity($"ProcessNextGrainEvent/{eventTypeName}", ActivityKind.Internal);
+
+        // Add event details to the activity
+        _activity?.SetTag("event.type", eventTypeName);
+        _activity?.SetTag("event.correlation_id", @event?.CorrelationId);
+        _activity?.SetTag("event.publisher_grain_id", @event?.PublisherGrainId);
+        _activity?.SetTag("event.consumer_grain_id", _grainId);
+        _activity?.SetTag("stream.sequence_number", token?.SequenceNumber.ToString());
+
+        // Add more descriptive tags
+        _activity?.SetTag("event.timestamp", DateTimeOffset.UtcNow.ToUnixTimeMilliseconds());
+    }
+
+    public void RecordException(Exception ex)
+    {
+        var errorType = ex.GetType().FullName;
+
+        _activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
+        _activity?.SetTag("error.type", errorType);
+        _activity?.SetTag("error.message", ex.Message);
+        _activity?.SetTag("error.stack_trace", ex.StackTrace);
+    }
+
+    public void Dispose()
+    {
+        _activity?.Stop();
+    }
+}


### PR DESCRIPTION
This is the first in a series of changes required to enable tracing/metrics in GAgent.

To make it work, Aevatar Station has to enable the source and OpenTelemetry.

Below is an example of the the result tracing span.

<img width="1915" alt="Screenshot 2025-04-14 at 4 52 57 PM" src="https://github.com/user-attachments/assets/8492cd5f-19da-4200-ae08-7495e5a586ad" />

**Note:** Latency metrics can be derived from the span time. Alternatively, metrics could be included in similar fashion as traces if necessary.