### PR TITLE
Store subscription handle id instead of handle object as alternative solution

### DIFF
--- a/src/Aevatar.Core.Abstractions/Application/BroadCastGState.cs
+++ b/src/Aevatar.Core.Abstractions/Application/BroadCastGState.cs
@@ -5,5 +5,5 @@ using Orleans.Streams;
 [GenerateSerializer]
 public class BroadCastGState : StateBase
 {
-    [Id(0)]public Dictionary<string, StreamSubscriptionHandle<EventWrapperBase>> Subscription = [];
+    [Id(0)]public Dictionary<string, Guid> Subscription = [];
 }


### PR DESCRIPTION
Orleans MongDB  Serializer does not serialise grain state private field, although the official document mentioned that private field is supported during serialisation.

As an alternative, we will store subscription handle id and filter the result from stream.GetAllSubscriptionHandles() instead

test: 
<img width="824" alt="pr-122" src="https://github.com/user-attachments/assets/fa96e574-dc0a-4025-a0e6-0cebe6ebc15d" />

no more errors in log file during silo restart with 8000 agents
