### PR TITLE
[Feature] Support multiple projector per agent type

### DIFF
--- a/src/Aevatar.Core.Abstractions/AevatarCoreConstants.cs
+++ b/src/Aevatar.Core.Abstractions/AevatarCoreConstants.cs
@@ -2,6 +2,7 @@ namespace Aevatar.Core.Abstractions;
 
 public class AevatarCoreConstants
 {
+    public const int DefaultNumOfProjectorPerAgentType = 8;
     public const string StreamProvider = "Aevatar";
     public const char GAgentNamespaceSeparator = '.';
 }

--- a/src/Aevatar.Core/Projections/StateProjectionGrain.cs
+++ b/src/Aevatar.Core/Projections/StateProjectionGrain.cs
@@ -15,16 +15,20 @@ public class StateProjectionGrain<TState> : Grain, IProjectionGrain<TState>
     private ILogger<StateProjectionGrain<TState>> _logger;
     private bool _activated = false;
 
+    private readonly IPersistentState<int> _id;
+
     public StateProjectionGrain(ILogger<StateProjectionGrain<TState>> logger,
-        IOptionsSnapshot<AevatarOptions> aevatarOptions)
+        IOptionsSnapshot<AevatarOptions> aevatarOptions,
+        [PersistentState("id", "PubSubStore")] IPersistentState<int> id)
     {
+        _id = id;
         _logger = logger;
         AevatarOptions = aevatarOptions.Value;
     }
 
     public Task ActivateAsync()
     {
-        _logger.LogInformation("Someone activated StateProjectionGrain<{TState}>", typeof(TState).Name);
+        _logger.LogInformation("Someone activated StateProjectionGrain<{TState}>, id={State}", typeof(TState).Name, _id.State);
         return Task.CompletedTask;
     }
 
@@ -34,6 +38,18 @@ public class StateProjectionGrain<TState> : Grain, IProjectionGrain<TState>
         {
             _logger.LogInformation("State projection stream for {TState} already activated.", typeof(TState).Name);
             return;
+        }
+
+        _logger.LogDebug("[RequestContext][{0}]Projector Index: {1}", typeof(TState).Name, RequestContext.Get("id"));
+        if (RequestContext.Get("id") is int id)
+        {
+            _id.State = id;
+            await _id.WriteStateAsync();
+            _logger.LogInformation("State projection grain for {TState} set id to {Id}", typeof(TState).Name, id);
+        }
+        else
+        {
+            _logger.LogWarning("RequestContext does not contain a valid 'id' for StateProjectionGrain<{TState}>.", typeof(TState).Name);
         }
 
         await base.OnActivateAsync(cancellationToken);
@@ -90,7 +106,8 @@ public class StateProjectionGrain<TState> : Grain, IProjectionGrain<TState>
 
     private IAsyncStream<StateWrapper<TState>> GetStateProjectionStream()
     {
-        var streamId = StreamId.Create(AevatarOptions.StateProjectionStreamNamespace, typeof(StateWrapper<TState>).FullName!);
+        var streamId = StreamId.Create(AevatarOptions.StateProjectionStreamNamespace, typeof(StateWrapper<TState>).FullName! + _id.State);
+        _logger.LogInformation("Getting state projection stream for {TState} with id {Id}", typeof(TState).Name, streamId);
         return StreamProvider.GetStream<StateWrapper<TState>>(streamId);
     }
 }

--- a/src/Aevatar.Core/Projections/StateProjectionGrain.cs
+++ b/src/Aevatar.Core/Projections/StateProjectionGrain.cs
@@ -7,6 +7,12 @@ using Orleans.Streams;
 
 namespace Aevatar.Core.Projections;
 
+[GenerateSerializer]
+public class ProjectionState: StateBase
+{
+    [Id(0)]public int Index { get; set; }
+}
+
 public class StateProjectionGrain<TState> : Grain, IProjectionGrain<TState>
     where TState : StateBase, new()
 {
@@ -15,20 +21,20 @@ public class StateProjectionGrain<TState> : Grain, IProjectionGrain<TState>
     private ILogger<StateProjectionGrain<TState>> _logger;
     private bool _activated = false;
 
-    private readonly IPersistentState<int> _id;
+    private readonly IPersistentState<ProjectionState> _projectionState;
 
     public StateProjectionGrain(ILogger<StateProjectionGrain<TState>> logger,
         IOptionsSnapshot<AevatarOptions> aevatarOptions,
-        [PersistentState("id", "PubSubStore")] IPersistentState<int> id)
+        [PersistentState("ProjectorIndex", "PubSubStore")] IPersistentState<ProjectionState> projectionState)
     {
-        _id = id;
+        _projectionState = projectionState;
         _logger = logger;
         AevatarOptions = aevatarOptions.Value;
     }
 
     public Task ActivateAsync()
     {
-        _logger.LogInformation("Someone activated StateProjectionGrain<{TState}>, id={State}", typeof(TState).Name, _id.State);
+        _logger.LogInformation("Someone activated StateProjectionGrain<{TState}>, id={State}", typeof(TState).Name, _projectionState.State.Index);
         return Task.CompletedTask;
     }
 
@@ -43,8 +49,8 @@ public class StateProjectionGrain<TState> : Grain, IProjectionGrain<TState>
         _logger.LogDebug("[RequestContext][{0}]Projector Index: {1}", typeof(TState).Name, RequestContext.Get("id"));
         if (RequestContext.Get("id") is int id)
         {
-            _id.State = id;
-            await _id.WriteStateAsync();
+            _projectionState.State.Index = id;
+            await _projectionState.WriteStateAsync();
             _logger.LogInformation("State projection grain for {TState} set id to {Id}", typeof(TState).Name, id);
         }
         else
@@ -106,7 +112,7 @@ public class StateProjectionGrain<TState> : Grain, IProjectionGrain<TState>
 
     private IAsyncStream<StateWrapper<TState>> GetStateProjectionStream()
     {
-        var streamId = StreamId.Create(AevatarOptions.StateProjectionStreamNamespace, typeof(StateWrapper<TState>).FullName! + _id.State);
+        var streamId = StreamId.Create(AevatarOptions.StateProjectionStreamNamespace, typeof(StateWrapper<TState>).FullName! + _projectionState.State.Index);
         _logger.LogInformation("Getting state projection stream for {TState} with id {Id}", typeof(TState).Name, streamId);
         return StreamProvider.GetStream<StateWrapper<TState>>(streamId);
     }


### PR DESCRIPTION
### Description
- Introduce a constant value that defines the multiplier. The total projector per agent = multiplier * (Number of agent state type)
- Use requestContext to pass the projector index from initializer 
- Implement a simple hashing based LB to distribute event in dispatcher

### Test
- state change events are assigned to different shards

<img width="1664" alt="Screenshot 2025-04-30 at 14 20 41" src="https://github.com/user-attachments/assets/5f9e3565-2924-4a57-ba29-75f5092e91d7" />

- State is saved

<img width="783" alt="Screenshot 2025-04-30 at 15 42 50" src="https://github.com/user-attachments/assets/038b0a19-8e4b-49ae-9d61-28b3e0c0a7ce" />


