### PR TITLE
[Fix] Dispatch to non-indexed projector stream

### DIFF
--- a/src/Aevatar.Core.Abstractions/IStateDispatcher.cs
+++ b/src/Aevatar.Core.Abstractions/IStateDispatcher.cs
@@ -3,4 +3,5 @@ namespace Aevatar.Core.Abstractions;
 public interface IStateDispatcher
 {
     Task PublishAsync<TState>(GrainId grainId, StateWrapper<TState> stateWrapper) where TState : StateBase;
+    Task PublishSingleAsync<TState>(GrainId grainId, StateWrapper<TState> stateWrapper) where TState : StateBase;
 }

--- a/src/Aevatar.Core/GAgentBase.cs
+++ b/src/Aevatar.Core/GAgentBase.cs
@@ -353,6 +353,8 @@ public abstract partial class
         await HandleStateChangedAsync();
         if (StateDispatcher != null)
         {
+            await StateDispatcher.PublishSingleAsync(this.GetGrainId(),
+                new StateWrapper<TState>(this.GetGrainId(), State, Version));
             await StateDispatcher.PublishAsync(this.GetGrainId(),
                 new StateWrapper<TState>(this.GetGrainId(), State, Version));
         }


### PR DESCRIPTION
retest:

<img width="655" alt="Screenshot 2025-04-30 at 18 43 35" src="https://github.com/user-attachments/assets/083b05c7-4b99-4312-bc53-ab0d51f8faaa" />

all unit tests:
<img width="650" alt="Screenshot 2025-04-30 at 18 48 44" src="https://github.com/user-attachments/assets/81603295-61e1-4b4e-988a-5bff929162f3" />


