### PR TITLE
[Feature] Silo Name Pattern Placement Strategy

### DIFF
--- a/samples/MessagingGAgent.Grains/Agents/Messaging/SpecializedGrain.cs
+++ b/samples/MessagingGAgent.Grains/Agents/Messaging/SpecializedGrain.cs
@@ -9,7 +9,7 @@ public class SpecializedGrain : Orleans.Grain, ISpecializedGrain
 {
     public Task DoSomethingAsync()
     {
-        // This grain will be activated on a silo whose name contains "Analytics" if available
+        // This grain will be activated on a silo whose name begins with "Analytics" if available
         // For example, it will match "AnalyticsSilo-01", "DataAnalytics", etc.
         Console.WriteLine($"Grain activated on silo: {this.RuntimeIdentity}");
         return Task.CompletedTask;

--- a/samples/MessagingGAgent.Grains/Agents/Messaging/SpecializedGrain.cs
+++ b/samples/MessagingGAgent.Grains/Agents/Messaging/SpecializedGrain.cs
@@ -1,0 +1,25 @@
+using Aevatar.Core.Placement;
+
+namespace MessagingGAgent.Grains;
+/// <summary>
+/// Example of a grain class that uses the SiloNamePatternPlacement attribute to specify placement.
+/// </summary>
+[SiloNamePatternPlacement("Analytics")]
+public class SpecializedGrain : Orleans.Grain, ISpecializedGrain
+{
+    public Task DoSomethingAsync()
+    {
+        // This grain will be activated on a silo whose name contains "Analytics" if available
+        // For example, it will match "AnalyticsSilo-01", "DataAnalytics", etc.
+        Console.WriteLine($"Grain activated on silo: {this.RuntimeIdentity}");
+        return Task.CompletedTask;
+    }
+}
+
+/// <summary>
+/// Interface for the specialized grain example.
+/// </summary>
+public interface ISpecializedGrain : Orleans.IGrainWithGuidKey
+{
+    Task DoSomethingAsync();
+}

--- a/samples/MessagingGAgent.Silo/Program.cs
+++ b/samples/MessagingGAgent.Silo/Program.cs
@@ -1,7 +1,12 @@
 ﻿using Aevatar.Core.Abstractions;
+using Orleans.Configuration;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using Aevatar.Core.Placement;
 
+/// Set your Orleans Silo name pattern in the environment variable SILO_NAME_PATTERN.
+
+var siloNamePattern = "No-Analytics-Silo";
 var builder = Host.CreateDefaultBuilder(args)
     .UseOrleans(silo =>
     {
@@ -10,9 +15,20 @@ var builder = Host.CreateDefaultBuilder(args)
             .AddMemoryGrainStorage("PubSubStore")
             .AddLogStorageBasedLogConsistencyProvider("LogStorage")
             .UseLocalhostClustering()
+            .Configure<SiloOptions>(options =>
+                    {
+                        options.SiloName = $"{siloNamePattern}-{Guid.NewGuid().ToString("N").Substring(0, 6)}";
+                    })
             .ConfigureLogging(logging => logging.AddConsole());
     })
     .UseConsoleLifetime();
+
+builder.ConfigureServices((context, services) =>
+        {
+            // Register the SiloNamePatternPlacement director
+            services.AddPlacementDirector<SiloNamePatternPlacement, SiloNamePatternPlacementDirector>();
+
+        });
 
 using var host = builder.Build();
 

--- a/samples/SiloNamePatternPlacementExamples/Program.cs
+++ b/samples/SiloNamePatternPlacementExamples/Program.cs
@@ -1,0 +1,78 @@
+﻿using Aevatar.Core.Abstractions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Orleans.Runtime.Placement;
+
+using Aevatar.Core.Placement;
+using MessagingGAgent.Grains;
+
+namespace Aevatar.Examples
+{
+    public static class Program
+    {
+        public static async Task Main(string[] args)
+        {
+            try
+            {
+                // Call the ConfigureExampleAsync method as the entry point
+                await SiloNamePatternPlacementExamples.ConfigureExampleAsync();
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"An error occurred: {ex.Message}");
+                throw;
+            }
+        }
+    }    
+
+    /// <summary>
+    /// Examples demonstrating how to use the SiloNamePatternPlacement strategy.
+    /// </summary>
+    public static class SiloNamePatternPlacementExamples
+    {
+        /// <summary>
+        /// Example showing how to configure a silo host to use the SiloNamePatternPlacement strategy.
+        /// </summary>
+        public static async Task ConfigureExampleAsync()
+        {
+            // Configure and start a silo with the SiloNamePatternPlacement strategy
+            IHostBuilder builder = Host.CreateDefaultBuilder()
+                .UseOrleansClient(client =>
+                {
+                    client.UseLocalhostClustering();
+                })
+                .ConfigureLogging(logging => logging.AddConsole())
+                .UseConsoleLifetime();
+
+            using IHost host = builder.Build();
+
+            await host.StartAsync();
+            // Create a client to interact with the silo
+            var client = host.Services.GetRequiredService<IClusterClient>();
+
+            await CallWithPlacementHintAsync(client.GetGrain<ISpecializedGrain>(Guid.NewGuid()));
+            // Wait for a while to allow the grain call to complete
+            await Task.Delay(1000);
+            await host.StopAsync();
+        }
+
+        /// <summary>
+        /// Example demonstrating how to programmatically set a placement hint for a grain call.
+        /// </summary>
+        /// <param name="grain">The grain to call.</param>
+        /// <returns>A task representing the asynchronous operation.</returns>
+        public static async Task CallWithPlacementHintAsync(ISpecializedGrain grain)
+        {
+            // Set the placement hint to target silos whose names contain "Analytics"
+            // This will match silos like "AnalyticsSilo-01", "AnalyticsSilo-02", etc.
+            RequestContext.Set(SiloNamePatternPlacement.SiloNamePatternPropertyKey, "Analytics");
+            
+            // This call will be routed to a silo whose name contains "Analytics" if available
+            await grain.DoSomethingAsync();
+            
+            // Clear the placement hint after the call
+            RequestContext.Remove(SiloNamePatternPlacement.SiloNamePatternPropertyKey);
+        }
+    }
+} 

--- a/samples/SiloNamePatternPlacementExamples/Program.cs
+++ b/samples/SiloNamePatternPlacementExamples/Program.cs
@@ -68,7 +68,7 @@ namespace Aevatar.Examples
             // This will match silos like "AnalyticsSilo-01", "AnalyticsSilo-02", etc.
             RequestContext.Set(SiloNamePatternPlacement.SiloNamePatternPropertyKey, "Analytics");
             
-            // This call will be routed to a silo whose name contains "Analytics" if available
+            // This call will be routed to a silo whose name begins with "Analytics" if available
             await grain.DoSomethingAsync();
             
             // Clear the placement hint after the call

--- a/samples/SiloNamePatternPlacementExamples/SiloNamePatternPlacementExamples.csproj
+++ b/samples/SiloNamePatternPlacementExamples/SiloNamePatternPlacementExamples.csproj
@@ -1,0 +1,22 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Orleans.Client" />
+    <PackageReference Include="Microsoft.Orleans.Sdk" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\MessagingGAgent.Grains\MessagingGAgent.Grains.csproj" />
+    <ProjectReference Include="..\..\src\Aevatar.Core\Aevatar.Core.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Aevatar.Core/Placement/SiloNamePatternPlacement.cs
+++ b/src/Aevatar.Core/Placement/SiloNamePatternPlacement.cs
@@ -118,9 +118,8 @@ namespace Aevatar.Core.Placement
 
             if (string.IsNullOrWhiteSpace(siloNamePattern))
             {
-                // If no silo name pattern is specified, extract it from the grain's primary key
-                // This assumes the grain ID might contain information about target silo
-                siloNamePattern = target.GrainIdentity.Key.ToString();
+                throw new OrleansException($"SiloNamePatternPlacement strategy requires a valid silo name pattern. " +
+                                            $"Current pattern: '{siloNamePattern}'");
             }
 
             var compatibleSilos = context.GetCompatibleSilos(target);

--- a/src/Aevatar.Core/Placement/SiloNamePatternPlacement.cs
+++ b/src/Aevatar.Core/Placement/SiloNamePatternPlacement.cs
@@ -28,9 +28,9 @@ namespace Aevatar.Core.Placement
 
         /// <summary>
         /// Gets or sets the silo name pattern used to match against silo names.
-        /// Grain will be activated on a silo whose name contains this pattern.
+        /// Grain will be activated on a silo whose name begins with this pattern.
         /// </summary>
-        [Id(1)]
+        [Id(0)]
         public string SiloNamePattern { get; private set; }
 
         /// <summary>
@@ -43,7 +43,7 @@ namespace Aevatar.Core.Placement
         /// <summary>
         /// Creates a new instance of the <see cref="SiloNamePatternPlacement"/> class with the specified silo name pattern.
         /// </summary>
-        /// <param name="siloNamePattern">The pattern to match against silo names. Grain will be activated on a silo whose name contains this pattern.</param>
+        /// <param name="siloNamePattern">The pattern to match against silo names. Grain will be activated on a silo whose name begins with this pattern.</param>
         /// <returns>A new instance of <see cref="SiloNamePatternPlacement"/> with the specified silo name pattern.</returns>
         public static SiloNamePatternPlacement Create(string siloNamePattern)
         {
@@ -165,14 +165,14 @@ namespace Aevatar.Core.Placement
     public sealed class SiloNamePatternPlacementAttribute : PlacementAttribute
     {
         /// <summary>
-        /// Gets the name pattern to match silos. Grain will be activated on a silo whose name contains this pattern.
+        /// Gets the name pattern to match silos. Grain will be activated on a silo whose name begins with this pattern.
         /// </summary>
         public string SiloNamePattern { get; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="SiloNamePatternPlacementAttribute"/> class.
         /// </summary>
-        /// <param name="siloNamePattern">The pattern to match silo names. Grain will be activated on a silo whose name contains this pattern.</param>
+        /// <param name="siloNamePattern">The pattern to match silo names. Grain will be activated on a silo whose name begins with this pattern.</param>
         public SiloNamePatternPlacementAttribute(string siloNamePattern)
             : base(SiloNamePatternPlacement.Create(siloNamePattern))
         {

--- a/src/Aevatar.Core/Placement/SiloNamePatternPlacement.cs
+++ b/src/Aevatar.Core/Placement/SiloNamePatternPlacement.cs
@@ -1,0 +1,182 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Orleans.Metadata;
+using Orleans.Placement;
+using Orleans.Runtime;
+using Orleans.Runtime.Placement;
+
+namespace Aevatar.Core.Placement
+{
+    /// <summary>
+    /// A placement strategy which places grains on silos based on a name pattern.
+    /// This allows for targeting silos whose names contain a specific substring.
+    /// </summary>
+    [Serializable, GenerateSerializer, Immutable, SuppressReferenceTracking]
+    public sealed class SiloNamePatternPlacement : PlacementStrategy
+    {
+        /// <summary>
+        /// Gets the singleton instance of this class.
+        /// </summary>
+        internal static SiloNamePatternPlacement Singleton { get; } = new SiloNamePatternPlacement();
+
+        /// <summary>
+        /// The property key used to store the silo name pattern in grain properties.
+        /// </summary>
+        public const string SiloNamePatternPropertyKey = "Aevatar.Placement.SiloNamePattern";
+
+        /// <summary>
+        /// Gets or sets the silo name pattern used to match against silo names.
+        /// Grain will be activated on a silo whose name contains this pattern.
+        /// </summary>
+        [Id(1)]
+        public string SiloNamePattern { get; private set; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SiloNamePatternPlacement"/> class.
+        /// </summary>
+        public SiloNamePatternPlacement()
+        {
+        }
+
+        /// <summary>
+        /// Creates a new instance of the <see cref="SiloNamePatternPlacement"/> class with the specified silo name pattern.
+        /// </summary>
+        /// <param name="siloNamePattern">The pattern to match against silo names. Grain will be activated on a silo whose name contains this pattern.</param>
+        /// <returns>A new instance of <see cref="SiloNamePatternPlacement"/> with the specified silo name pattern.</returns>
+        public static SiloNamePatternPlacement Create(string siloNamePattern)
+        {
+            var instance = new SiloNamePatternPlacement
+            {
+                SiloNamePattern = siloNamePattern
+            };
+            return instance;
+        }
+
+        /// <summary>
+        /// Initializes an instance of this type using the provided grain properties.
+        /// </summary>
+        /// <param name="properties">The grain properties.</param>
+        public override void Initialize(GrainProperties properties)
+        {
+            base.Initialize(properties);
+            
+            // Extract silo name pattern from grain properties if available
+            if (properties.Properties.TryGetValue(SiloNamePatternPropertyKey, out var siloNamePattern))
+            {
+                SiloNamePattern = siloNamePattern;
+            }
+        }
+
+        /// <summary>
+        /// Populates grain properties to specify the preferred placement strategy.
+        /// </summary>
+        /// <param name="services">The service provider.</param>
+        /// <param name="grainClass">The grain class.</param>
+        /// <param name="grainType">The grain type.</param>
+        /// <param name="properties">The grain properties which will be populated by this method call.</param>
+        public override void PopulateGrainProperties(IServiceProvider services, Type grainClass, GrainType grainType, Dictionary<string, string> properties)
+        {
+            base.PopulateGrainProperties(services, grainClass, grainType, properties);
+            
+            // Store the silo name pattern in grain properties
+            if (!string.IsNullOrWhiteSpace(SiloNamePattern))
+            {
+                properties[SiloNamePatternPropertyKey] = SiloNamePattern;
+            }
+        }
+    }
+
+    /// <summary>
+    /// A placement director which places grain activations on silos whose names match a specified pattern.
+    /// </summary>
+    public class SiloNamePatternPlacementDirector : IPlacementDirector
+    {
+        private readonly ISiloStatusOracle _siloStatusOracle;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SiloNamePatternPlacementDirector"/> class.
+        /// </summary>
+        /// <param name="siloStatusOracle">The silo status oracle.</param>
+        public SiloNamePatternPlacementDirector(ISiloStatusOracle siloStatusOracle)
+        {
+            _siloStatusOracle = siloStatusOracle ?? throw new ArgumentNullException(nameof(siloStatusOracle));
+        }
+
+        /// <summary>
+        /// Picks an appropriate silo to place the specified target on based on the silo name pattern.
+        /// </summary>
+        /// <param name="strategy">The target's placement strategy.</param>
+        /// <param name="target">The grain being placed as well as information about the request which triggered the placement.</param>
+        /// <param name="context">The placement context.</param>
+        /// <returns>An appropriate silo to place the specified target on.</returns>
+        public Task<SiloAddress> OnAddActivation(PlacementStrategy strategy, PlacementTarget target, IPlacementContext context)
+        {
+            var siloNamePatternStrategy = strategy as SiloNamePatternPlacement;
+            var siloNamePattern = siloNamePatternStrategy?.SiloNamePattern;
+
+            if (string.IsNullOrWhiteSpace(siloNamePattern))
+            {
+                // If no silo name pattern is specified, extract it from the grain's primary key
+                // This assumes the grain ID might contain information about target silo
+                siloNamePattern = target.GrainIdentity.Key.ToString();
+            }
+
+            var compatibleSilos = context.GetCompatibleSilos(target);
+
+            // If a valid placement hint was specified, use it.
+            if (IPlacementDirector.GetPlacementHint(target.RequestContextData, compatibleSilos) is { } placementHint)
+            {
+                return Task.FromResult(placementHint);
+            }
+
+            // Get all active silos
+            var siloStatuses = _siloStatusOracle.GetApproximateSiloStatuses(onlyActive: true);
+            
+            // Find all active silos whose names contain the specified pattern
+            var matchingSilos = new List<SiloAddress>();
+            // Iterate over compatible silos directly (likely fewer items)
+            foreach (var siloAddress in compatibleSilos)
+            {
+                // Only check status/name for compatible silos
+                if (_siloStatusOracle.TryGetSiloName(siloAddress, out var siloName) &&
+                    siloName.StartsWith(siloNamePattern, StringComparison.OrdinalIgnoreCase))
+                {
+                    matchingSilos.Add(siloAddress);
+                }
+            }
+
+            if (matchingSilos.Count == 0)
+            {
+                // If no matching silos found, throw an exception
+                throw new OrleansException($"No silos matching pattern '{siloNamePattern}' found. Available silos: {string.Join(", ", compatibleSilos.Select(s => s.ToString()))}");
+            }
+
+            // Randomly select one of the matching silos
+            return Task.FromResult(matchingSilos[Random.Shared.Next(matchingSilos.Count)]);
+        }
+    }
+
+    /// <summary>
+    /// Attribute used to specify that a grain should be placed on silos whose names match a specified pattern.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false)]
+    public sealed class SiloNamePatternPlacementAttribute : PlacementAttribute
+    {
+        /// <summary>
+        /// Gets the name pattern to match silos. Grain will be activated on a silo whose name contains this pattern.
+        /// </summary>
+        public string SiloNamePattern { get; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SiloNamePatternPlacementAttribute"/> class.
+        /// </summary>
+        /// <param name="siloNamePattern">The pattern to match silo names. Grain will be activated on a silo whose name contains this pattern.</param>
+        public SiloNamePatternPlacementAttribute(string siloNamePattern)
+            : base(SiloNamePatternPlacement.Create(siloNamePattern))
+        {
+            SiloNamePattern = siloNamePattern ?? throw new ArgumentNullException(nameof(siloNamePattern));
+        }
+    }
+} 

--- a/src/Aevatar.Core/Projections/StateProjectionGrain.cs
+++ b/src/Aevatar.Core/Projections/StateProjectionGrain.cs
@@ -1,5 +1,6 @@
 using Aevatar.Core.Abstractions;
 using Aevatar.Core.Abstractions.Projections;
+using Aevatar.Core.Placement;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -13,6 +14,7 @@ public class ProjectionState: StateBase
     [Id(0)]public int Index { get; set; }
 }
 
+[SiloNamePatternPlacement("Projector")]
 public class StateProjectionGrain<TState> : Grain, IProjectionGrain<TState>
     where TState : StateBase, new()
 {
@@ -71,7 +73,8 @@ public class StateProjectionGrain<TState> : Grain, IProjectionGrain<TState>
         }
 
         _activated = true;
-        _logger.LogInformation("State projection stream for {TState} is activated and ready to use.", typeof(TState).Name);
+        _logger.LogInformation("State projection stream for {TState} is activated and ready to use on silo {SiloIdentity}.", 
+            typeof(TState).Name, this.RuntimeIdentity);
     }
 
     private async Task InitializeOrResumeStateProjectionStreamAsync()

--- a/test/Aevatar.Core.Tests/Aevatar.Core.Tests.csproj
+++ b/test/Aevatar.Core.Tests/Aevatar.Core.Tests.csproj
@@ -18,6 +18,7 @@
         <PackageReference Include="xunit" />
         <PackageReference Include="xunit.runner.visualstudio" />
         <PackageReference Include="Shouldly" />
+        <PackageReference Include="Moq" />
     </ItemGroup>
 
     <ItemGroup>

--- a/test/Aevatar.Core.Tests/Placement/SiloNamePatternPlacementTests.cs
+++ b/test/Aevatar.Core.Tests/Placement/SiloNamePatternPlacementTests.cs
@@ -131,6 +131,57 @@ namespace Aevatar.Core.Tests.Placement
             result.ShouldNotBe(analyticsSilo);
         }
         
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("   ")]
+        public async Task SiloNamePatternPlacementDirector_OnAddActivation_NullOrWhiteSpacePattern_ThrowsException(string? invalidPattern)
+        {
+            // Arrange
+            // Create mock silo addresses
+            var silo1 = SiloAddress.New(new System.Net.IPEndPoint(System.Net.IPAddress.Loopback, 11111), 0);
+            var silo2 = SiloAddress.New(new System.Net.IPEndPoint(System.Net.IPAddress.Loopback, 22222), 0);
+            
+            // Setup mock silo status oracle
+            var mockSiloStatusOracle = new Mock<ISiloStatusOracle>();
+            
+            // Setup silo statuses
+            var siloStatuses = new Dictionary<SiloAddress, SiloStatus>
+            {
+                { silo1, SiloStatus.Active },
+                { silo2, SiloStatus.Active }
+            };
+            mockSiloStatusOracle.Setup(x => x.GetApproximateSiloStatuses(true)).Returns(siloStatuses);
+            
+            // Setup mock placement context
+            var mockPlacementContext = new Mock<IPlacementContext>();
+            var compatibleSilos = new[] { silo1, silo2 };
+            mockPlacementContext.Setup(x => x.GetCompatibleSilos(It.IsAny<PlacementTarget>())).Returns(compatibleSilos);
+            
+            // Create placement strategy with null/empty/whitespace pattern
+            // Use reflection to set the pattern to null/empty/whitespace since the Create method won't allow it
+            var strategy = new SiloNamePatternPlacement();
+            typeof(SiloNamePatternPlacement).GetProperty("SiloNamePattern")!.SetValue(strategy, invalidPattern);
+            
+            // Create placement director
+            var director = new SiloNamePatternPlacementDirector(mockSiloStatusOracle.Object);
+            
+            // Create placement target
+            var target = new PlacementTarget(
+                GrainId.Create("TestGrain", "1"),
+                new Dictionary<string, object>(),
+                GrainInterfaceType.Create("ITestGrain"), 
+                1);
+            
+            // Act & Assert
+            var exception = await Assert.ThrowsAsync<OrleansException>(() => 
+                director.OnAddActivation(strategy, target, mockPlacementContext.Object));
+            
+            // Verify the exception message
+            exception.Message.ShouldContain("SiloNamePatternPlacement strategy requires a valid silo name pattern");
+            exception.Message.ShouldContain($"Current pattern: '{invalidPattern}'");
+        }
+        
         [Fact]
         public async Task SiloNamePatternPlacementDirector_OnAddActivation_NoMatchingPattern_ThrowsException()
         {

--- a/test/Aevatar.Core.Tests/Placement/SiloNamePatternPlacementTests.cs
+++ b/test/Aevatar.Core.Tests/Placement/SiloNamePatternPlacementTests.cs
@@ -1,0 +1,285 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Threading.Tasks;
+using Aevatar.Core.Placement;
+using Orleans.Runtime;
+using Orleans.Runtime.Placement;
+using Shouldly;
+using Xunit;
+using Moq;
+
+namespace Aevatar.Core.Tests.Placement
+{
+    public class SiloNamePatternPlacementTests
+    {
+        [Fact]
+        public void SiloNamePatternPlacement_Create_SetsPattern()
+        {
+            // Arrange
+            const string testPattern = "Analytics";
+            
+            // Act
+            var placement = SiloNamePatternPlacement.Create(testPattern);
+            
+            // Assert
+            placement.ShouldNotBeNull();
+            placement.ShouldBeOfType<SiloNamePatternPlacement>();
+            typeof(SiloNamePatternPlacement).GetProperty("SiloNamePattern")?.GetValue(placement).ShouldBe(testPattern);
+        }
+        
+        [Fact]
+        public void SiloNamePatternPlacement_Initialize_SetsPatternFromProperties()
+        {
+            // Arrange
+            var placement = new SiloNamePatternPlacement();
+            var properties = new Orleans.Metadata.GrainProperties(
+                ImmutableDictionary.CreateRange(new Dictionary<string, string>
+                {
+                    { SiloNamePatternPlacement.SiloNamePatternPropertyKey, "TestPattern" }
+                }));
+            
+            // Act
+            placement.Initialize(properties);
+            
+            // Assert
+            typeof(SiloNamePatternPlacement).GetProperty("SiloNamePattern")?.GetValue(placement).ShouldBe("TestPattern");
+        }
+        
+        [Fact]
+        public void SiloNamePatternPlacement_PopulateGrainProperties_AddsPatternToProperties()
+        {
+            // Arrange
+            const string testPattern = "Worker";
+            var placement = SiloNamePatternPlacement.Create(testPattern);
+            var properties = new Dictionary<string, string>();
+            
+            // Act
+            placement.PopulateGrainProperties(null!, null!, default, properties);
+            
+            // Assert
+            properties.ShouldContainKey(SiloNamePatternPlacement.SiloNamePatternPropertyKey);
+            properties[SiloNamePatternPlacement.SiloNamePatternPropertyKey].ShouldBe(testPattern);
+        }
+        
+        [Fact]
+        public async Task SiloNamePatternPlacementDirector_OnAddActivation_MatchesSiloNamePattern()
+        {
+            // Arrange
+            const string testPattern = "Worker";
+            
+            // Create mock silo addresses
+            var workerSilo1 = SiloAddress.New(new System.Net.IPEndPoint(System.Net.IPAddress.Loopback, 11111), 0);
+            var workerSilo2 = SiloAddress.New(new System.Net.IPEndPoint(System.Net.IPAddress.Loopback, 22222), 0);
+            var analyticsSilo = SiloAddress.New(new System.Net.IPEndPoint(System.Net.IPAddress.Loopback, 33333), 0);
+            
+            // Setup mock silo status oracle
+            var mockSiloStatusOracle = new Mock<ISiloStatusOracle>();
+            
+            // Setup silo statuses
+            var siloStatuses = new Dictionary<SiloAddress, SiloStatus>
+            {
+                { workerSilo1, SiloStatus.Active },
+                { workerSilo2, SiloStatus.Active },
+                { analyticsSilo, SiloStatus.Active }
+            };
+            mockSiloStatusOracle.Setup(x => x.GetApproximateSiloStatuses(true)).Returns(siloStatuses);
+            
+            // Setup silo names
+            string workerSilo1Name = "WorkerSilo-01";
+            string workerSilo2Name = "WorkerSilo-02";
+            string analyticsSiloName = "AnalyticsSilo";
+            
+            mockSiloStatusOracle
+                .Setup(m => m.TryGetSiloName(workerSilo1, out workerSilo1Name))
+                .Returns(true);
+                
+            mockSiloStatusOracle
+                .Setup(m => m.TryGetSiloName(workerSilo2, out workerSilo2Name))
+                .Returns(true);
+                
+            mockSiloStatusOracle
+                .Setup(m => m.TryGetSiloName(analyticsSilo, out analyticsSiloName))
+                .Returns(true);
+            
+            // Setup mock placement context
+            var mockPlacementContext = new Mock<IPlacementContext>();
+            var compatibleSilos = new[] { workerSilo1, workerSilo2, analyticsSilo };
+            mockPlacementContext.Setup(x => x.GetCompatibleSilos(It.IsAny<PlacementTarget>())).Returns(compatibleSilos);
+            
+            // Create placement strategy
+            var strategy = SiloNamePatternPlacement.Create(testPattern);
+            
+            // Create placement director
+            var director = new SiloNamePatternPlacementDirector(mockSiloStatusOracle.Object);
+            
+            // Create placement target
+            var target = new PlacementTarget(
+                GrainId.Create("TestGrain", "1"),
+                new Dictionary<string, object>(),
+                GrainInterfaceType.Create("ITestGrain"), 
+                1);
+            
+            // Act
+            var result = await director.OnAddActivation(strategy, target, mockPlacementContext.Object);
+            
+            // Assert
+            result.ShouldNotBeNull();
+            // Should be one of the worker silos
+            result.ShouldBeOneOf(workerSilo1, workerSilo2);
+            // Should not be the analytics silo
+            result.ShouldNotBe(analyticsSilo);
+        }
+        
+        [Fact]
+        public async Task SiloNamePatternPlacementDirector_OnAddActivation_NoMatchingPattern_ThrowsException()
+        {
+            // Arrange
+            const string testPattern = "NonExistent";
+            
+            // Create mock silo addresses
+            var workerSilo = SiloAddress.New(new System.Net.IPEndPoint(System.Net.IPAddress.Loopback, 11111), 0);
+            var analyticsSilo = SiloAddress.New(new System.Net.IPEndPoint(System.Net.IPAddress.Loopback, 22222), 0);
+            
+            // Setup mock silo status oracle
+            var mockSiloStatusOracle = new Mock<ISiloStatusOracle>();
+            
+            // Setup silo statuses
+            var siloStatuses = new Dictionary<SiloAddress, SiloStatus>
+            {
+                { workerSilo, SiloStatus.Active },
+                { analyticsSilo, SiloStatus.Active }
+            };
+            mockSiloStatusOracle.Setup(x => x.GetApproximateSiloStatuses(true)).Returns(siloStatuses);
+            
+            // Setup silo names
+            string workerSiloName = "WorkerSilo";
+            string analyticsSiloName = "AnalyticsSilo";
+            
+            mockSiloStatusOracle
+                .Setup(m => m.TryGetSiloName(workerSilo, out workerSiloName))
+                .Returns(true);
+                
+            mockSiloStatusOracle
+                .Setup(m => m.TryGetSiloName(analyticsSilo, out analyticsSiloName))
+                .Returns(true);
+            
+            // Setup mock placement context
+            var mockPlacementContext = new Mock<IPlacementContext>();
+            var compatibleSilos = new[] { workerSilo, analyticsSilo };
+            mockPlacementContext.Setup(x => x.GetCompatibleSilos(It.IsAny<PlacementTarget>())).Returns(compatibleSilos);
+            
+            // Create placement strategy
+            var strategy = SiloNamePatternPlacement.Create(testPattern);
+            
+            // Create placement director
+            var director = new SiloNamePatternPlacementDirector(mockSiloStatusOracle.Object);
+            
+            // Create placement target
+            var target = new PlacementTarget(
+                GrainId.Create("TestGrain", "1"),
+                new Dictionary<string, object>(),
+                GrainInterfaceType.Create("ITestGrain"), 
+                1);
+            
+            // Act & Assert
+            var exception = await Assert.ThrowsAsync<OrleansException>(() => 
+                director.OnAddActivation(strategy, target, mockPlacementContext.Object));
+            
+            // Verify the exception message contains relevant information
+            exception.Message.ShouldContain(testPattern);
+            exception.Message.ShouldContain("No silos matching pattern");
+            exception.Message.ShouldContain(workerSilo.ToString());
+            exception.Message.ShouldContain(analyticsSilo.ToString());
+        }
+        
+        [Fact]
+        public void SiloNamePatternPlacementAttribute_Constructor_SetsPatternProperty()
+        {
+            // Arrange & Act
+            var attribute = new SiloNamePatternPlacementAttribute("TestPattern");
+            
+            // Assert
+            attribute.ShouldNotBeNull();
+            attribute.SiloNamePattern.ShouldBe("TestPattern");
+            attribute.PlacementStrategy.ShouldBeOfType<SiloNamePatternPlacement>();
+        }
+        
+        [Fact]
+        public async Task DefaultPlacement_NotAffectedBy_SiloNamePatternPlacement()
+        {
+            // Arrange
+            // Create mock silo addresses
+            var silo1 = SiloAddress.New(new System.Net.IPEndPoint(System.Net.IPAddress.Loopback, 11111), 0);
+            var silo2 = SiloAddress.New(new System.Net.IPEndPoint(System.Net.IPAddress.Loopback, 22222), 0);
+            var silo3 = SiloAddress.New(new System.Net.IPEndPoint(System.Net.IPAddress.Loopback, 33333), 0);
+            
+            // Setup mock silo status oracle
+            var mockSiloStatusOracle = new Mock<ISiloStatusOracle>();
+            
+            // Setup silo statuses - all silos are active
+            var siloStatuses = new Dictionary<SiloAddress, SiloStatus>
+            {
+                { silo1, SiloStatus.Active },
+                { silo2, SiloStatus.Active },
+                { silo3, SiloStatus.Active }
+            };
+            mockSiloStatusOracle.Setup(x => x.GetApproximateSiloStatuses(true)).Returns(siloStatuses);
+            
+            // Setup silo names (even though they won't be used by default placement)
+            var silo1Name = "Silo1";
+            var silo2Name = "Silo2";
+            var silo3Name = "Silo3";
+            
+            mockSiloStatusOracle.Setup(m => m.TryGetSiloName(silo1, out silo1Name)).Returns(true);
+            mockSiloStatusOracle.Setup(m => m.TryGetSiloName(silo2, out silo2Name)).Returns(true);
+            mockSiloStatusOracle.Setup(m => m.TryGetSiloName(silo3, out silo3Name)).Returns(true);
+            
+            // Create a mock default placement director
+            var mockDefaultPlacementDirector = new Mock<IPlacementDirector>();
+            mockDefaultPlacementDirector
+                .Setup(d => d.OnAddActivation(
+                    It.IsAny<PlacementStrategy>(), 
+                    It.IsAny<PlacementTarget>(), 
+                    It.IsAny<IPlacementContext>()))
+                .ReturnsAsync(silo1); // Default placement would return silo1
+            
+            // Setup mock placement context
+            var mockPlacementContext = new Mock<IPlacementContext>();
+            var compatibleSilos = new[] { silo1, silo2, silo3 };
+            mockPlacementContext.Setup(x => x.GetCompatibleSilos(It.IsAny<PlacementTarget>())).Returns(compatibleSilos);
+            
+            // Create a standard Orleans placement strategy that is NOT SiloNamePatternPlacement
+            var defaultStrategy = new RandomPlacement();
+            
+            // Create placement target 
+            var target = new PlacementTarget(
+                GrainId.Create("DefaultGrain", "1"),
+                new Dictionary<string, object>(),
+                GrainInterfaceType.Create("IDefaultGrain"), 
+                1);
+            
+            // Act
+            var result = await mockDefaultPlacementDirector.Object.OnAddActivation(
+                defaultStrategy, target, mockPlacementContext.Object);
+            
+            // Assert
+            result.ShouldNotBeNull();
+            result.ShouldBe(silo1); // Should be the silo that the default placement director returned
+            
+            // Verify the default placement director was called with the expected parameters
+            mockDefaultPlacementDirector.Verify(
+                d => d.OnAddActivation(
+                    It.Is<PlacementStrategy>(s => s == defaultStrategy),
+                    It.IsAny<PlacementTarget>(),
+                    It.Is<IPlacementContext>(c => c == mockPlacementContext.Object)),
+                Times.Once);
+                
+            // Verify that no methods were called on our SiloNamePatternPlacementDirector
+            var ourDirector = new SiloNamePatternPlacementDirector(mockSiloStatusOracle.Object);
+            // This is a structural verification - our code can't actually track calls on a newly created object
+            // The real verification is that the default placement works as expected
+            defaultStrategy.ShouldNotBeOfType<SiloNamePatternPlacement>();
+        }
+    }
+} 

--- a/test/Aevatar.Core.Tests/Placement/SiloNamePatternRegistrationTests.cs
+++ b/test/Aevatar.Core.Tests/Placement/SiloNamePatternRegistrationTests.cs
@@ -1,0 +1,66 @@
+using System.Linq;
+using Aevatar.Core.Placement;
+using Microsoft.Extensions.DependencyInjection;
+using Orleans.Runtime.Placement;
+using Shouldly;
+using Xunit;
+using Moq;
+
+namespace Aevatar.Core.Tests.Placement
+{
+    public class SiloNamePatternRegistrationTests
+    {
+        [Fact]
+        public void PlacementDirector_Registration_ShouldRegisterCorrectly()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+            
+            // Register required services for SiloNamePatternPlacementDirector
+            var siloStatusOracle = Mock.Of<ISiloStatusOracle>();
+            services.AddSingleton(siloStatusOracle);
+            
+            // Register the director directly without the extension method
+            services.AddSingleton<SiloNamePatternPlacementDirector>();
+
+            var serviceProvider = services.BuildServiceProvider();
+
+            // Assert
+            var director = serviceProvider.GetService<SiloNamePatternPlacementDirector>();
+            director.ShouldNotBeNull();
+        }
+
+        [Fact]
+        public void PlacementStrategy_Registration_WithPattern_ShouldRegisterCorrectly()
+        {
+            // Arrange
+            var services = new ServiceCollection();
+            const string testPattern = "TestPattern";
+            
+            // Register required services and create the pattern placement
+            var siloStatusOracle = Mock.Of<ISiloStatusOracle>();
+            services.AddSingleton(siloStatusOracle);
+            
+            // Register the director
+            services.AddSingleton<SiloNamePatternPlacementDirector>();
+            
+            // Register the strategy with a specific pattern
+            services.AddSingleton(SiloNamePatternPlacement.Create(testPattern));
+            services.AddSingleton<PlacementStrategy>(sp => sp.GetRequiredService<SiloNamePatternPlacement>());
+
+            var serviceProvider = services.BuildServiceProvider();
+
+            // Assert
+            var strategy = serviceProvider.GetService<SiloNamePatternPlacement>();
+            strategy.ShouldNotBeNull();
+            
+            var property = typeof(SiloNamePatternPlacement).GetProperty("SiloNamePattern")!;
+            property.GetValue(strategy).ShouldBe(testPattern);
+            
+            // Verify it's also registered as a PlacementStrategy
+            var strategies = serviceProvider.GetServices<PlacementStrategy>().ToList();
+            strategies.Count.ShouldBeGreaterThan(0);
+            strategies.Any(s => s is SiloNamePatternPlacement).ShouldBeTrue();
+        }
+    }
+} 


### PR DESCRIPTION
### Changes
- Add RoleName pattern based placement strategy, when roleName matches, performs default placement strategy (random) among all matched silos
- Add unit tests
- Add e2e tests

### Unit Tests
<img width="392" alt="Screenshot 2025-05-05 at 11 18 24" src="https://github.com/user-attachments/assets/14ac9491-c8b2-4d43-9645-47af45d25f10" />


### E2E tests
Throws exception when mismatch: 
<img width="891" alt="Screenshot 2025-05-02 at 22 31 05" src="https://github.com/user-attachments/assets/2e79b44c-bdd3-49f9-84d9-b0de876c5548" />

Activated successfully when match:
<img width="840" alt="Screenshot 2025-05-02 at 22 14 47" src="https://github.com/user-attachments/assets/d16294bc-8970-4c6e-a3d7-6a03907255c6" />

