### PR TITLE
[Fix] The placement strategy causes the imbalance of grain distribution

### DIFF
--- a/src/Aevatar.Core/Placement/SiloNamePatternPlacement.cs
+++ b/src/Aevatar.Core/Placement/SiloNamePatternPlacement.cs
@@ -106,7 +106,7 @@ namespace Aevatar.Core.Placement
             GrainPropertiesResolver grainPropertiesResolver) 
         {
             _siloStatusOracle = siloStatusOracle ?? throw new ArgumentNullException(nameof(siloStatusOracle));
-            _grainPropertiesResolver = grainPropertiesResolver;
+            _grainPropertiesResolver = grainPropertiesResolver ?? throw new ArgumentNullException(nameof(grainPropertiesResolver));
         }
 
         /// <summary>

--- a/src/Aevatar.Core/Placement/SiloNamePatternPlacement.cs
+++ b/src/Aevatar.Core/Placement/SiloNamePatternPlacement.cs
@@ -94,14 +94,19 @@ namespace Aevatar.Core.Placement
     public class SiloNamePatternPlacementDirector : IPlacementDirector
     {
         private readonly ISiloStatusOracle _siloStatusOracle;
+        
+        private readonly GrainPropertiesResolver _grainPropertiesResolver;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="SiloNamePatternPlacementDirector"/> class.
         /// </summary>
         /// <param name="siloStatusOracle">The silo status oracle.</param>
-        public SiloNamePatternPlacementDirector(ISiloStatusOracle siloStatusOracle)
+        public SiloNamePatternPlacementDirector(
+            ISiloStatusOracle siloStatusOracle,
+            GrainPropertiesResolver grainPropertiesResolver) 
         {
             _siloStatusOracle = siloStatusOracle ?? throw new ArgumentNullException(nameof(siloStatusOracle));
+            _grainPropertiesResolver = grainPropertiesResolver;
         }
 
         /// <summary>
@@ -113,8 +118,15 @@ namespace Aevatar.Core.Placement
         /// <returns>An appropriate silo to place the specified target on.</returns>
         public Task<SiloAddress> OnAddActivation(PlacementStrategy strategy, PlacementTarget target, IPlacementContext context)
         {
-            var siloNamePatternStrategy = strategy as SiloNamePatternPlacement;
-            var siloNamePattern = siloNamePatternStrategy?.SiloNamePattern;
+            // Get pattern from grain properties
+            string siloNamePattern = null;
+            
+            // Try to get the grain properties for this grain type
+            if (_grainPropertiesResolver.TryGetGrainProperties(target.GrainIdentity.Type, out var properties) && 
+                properties.Properties.TryGetValue(SiloNamePatternPlacement.SiloNamePatternPropertyKey, out var pattern))
+            {
+                siloNamePattern = pattern;
+            }
 
             if (string.IsNullOrWhiteSpace(siloNamePattern))
             {


### PR DESCRIPTION
### Context
During the load test, it is observed that many grains are placed into wrong silos. This affects projector silos as there are total of 3 projector silos only

### Root cause
The placement strategy instance is shared by all grains hence the value of SiloNamePattern assigned by other grain will used to all following call until the instance is disposed. This explains why many grains are assigned to projector silo as projector grains are activated first. This also explained why some projector silos are assigned to user silo - after the strategy instance is disposed and recreated by a user grain activation call

### Changes

Store the name pattern of the grain in its own property using property key instead so that they won't interfere with each other


###Load Balancing
<img width="1696" alt="Screenshot 2025-05-08 at 17 35 07" src="https://github.com/user-attachments/assets/1a8e2b90-3b23-46a8-8639-2095ad05363b" />

### E2E Test: 
Create several "Schedule" agents and Hundreds of "User" agents

<img width="1676" alt="Screenshot 2025-05-08 at 11 49 25" src="https://github.com/user-attachments/assets/4f790d44-49fd-4f38-8f16-51ca14d6d2d3" />

<img width="1684" alt="Screenshot 2025-05-08 at 11 49 00" src="https://github.com/user-attachments/assets/c3763139-08fd-4bed-ac2c-6e7379eb3e60" />

<img width="1689" alt="Screenshot 2025-05-08 at 11 49 16" src="https://github.com/user-attachments/assets/0e762c22-f9a5-40ec-914a-d6850520f26f" />

### Unit Test

<img width="653" alt="Screenshot 2025-05-08 at 13 58 58" src="https://github.com/user-attachments/assets/540f20c3-c8a4-4142-9b67-dfe63d71e9c2" />

### Failed the failed test case

<img width="307" alt="Screenshot 2025-05-08 at 17 30 40" src="https://github.com/user-attachments/assets/cf24b0a3-8195-48ae-8918-d4f7876546fa" />

