### PR TITLE
[Feature][Performance]Support mongodb binary serializer storage

### DIFF
--- a/src/Aevatar.EventSourcing.MongoDB/Aevatar.EventSourcing.MongoDB.csproj
+++ b/src/Aevatar.EventSourcing.MongoDB/Aevatar.EventSourcing.MongoDB.csproj
@@ -19,6 +19,7 @@
       <PackageReference Include="Microsoft.Orleans.EventSourcing" />
       <PackageReference Include="MongoDB.Bson" />
       <PackageReference Include="MongoDB.Driver" />
+      <PackageReference Include="Orleans.Providers.MongoDB" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Aevatar.EventSourcing.MongoDB/Configuration/MongoDBGrainStorageConfigurator.cs
+++ b/src/Aevatar.EventSourcing.MongoDB/Configuration/MongoDBGrainStorageConfigurator.cs
@@ -1,0 +1,34 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Orleans.Providers.MongoDB.StorageProviders.Serializers;
+using System;
+
+using Aevatar.EventSourcing.MongoDB.Options;
+
+namespace Aevatar.EventSourcing.MongoDB.Configuration
+{
+    internal class MongoDBGrainStorageConfigurator : IPostConfigureOptions<MongoDbStorageOptions>
+    {
+        private readonly IServiceProvider _serviceProvider;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DefaultStateProviderSerializerOptionsConfigurator{TOptions}"/> class.
+        /// </summary>
+        /// <param name="serviceProvider">The service provider.</param>
+        public MongoDBGrainStorageConfigurator(IServiceProvider serviceProvider)
+        {
+            _serviceProvider = serviceProvider;
+        }
+
+        /// <inheritdoc/>
+        public void PostConfigure(string name, MongoDbStorageOptions options)
+        {
+            if (options.GrainStateSerializer == default)
+            {
+                // First, try to get a IGrainStateSerializer that was registered with the same name as the State provider
+                // If none is found, fallback to system wide default
+                options.GrainStateSerializer = _serviceProvider.GetKeyedService<IGrainStateSerializer>(name) ?? _serviceProvider.GetRequiredService<IGrainStateSerializer>();
+            }
+        }
+    }
+}

--- a/src/Aevatar.EventSourcing.MongoDB/Hosting/MongoDbStorageServiceCollectionExtensions.cs
+++ b/src/Aevatar.EventSourcing.MongoDB/Hosting/MongoDbStorageServiceCollectionExtensions.cs
@@ -1,6 +1,8 @@
 using Aevatar.EventSourcing.Core.LogConsistency;
 using Aevatar.EventSourcing.Core.Storage;
 using Aevatar.EventSourcing.MongoDB.Options;
+using Aevatar.EventSourcing.MongoDB.Configuration;
+
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Options;
@@ -43,7 +45,7 @@ public static class MongoDbStorageServiceCollectionExtensions
                 sp.GetRequiredService<IOptionsMonitor<MongoDbStorageOptions>>().Get(name), name));
         services
             .AddTransient<IPostConfigureOptions<MongoDbStorageOptions>,
-                DefaultStorageProviderSerializerOptionsConfigurator<MongoDbStorageOptions>>();
+                MongoDBGrainStorageConfigurator>();
         services.ConfigureNamedOptionForLogging<MongoDbStorageOptions>(name);
         if (string.Equals(name, ProviderConstants.DEFAULT_STORAGE_PROVIDER_NAME, StringComparison.Ordinal))
         {

--- a/src/Aevatar.EventSourcing.MongoDB/Options/MongoDbStorageOptions.cs
+++ b/src/Aevatar.EventSourcing.MongoDB/Options/MongoDbStorageOptions.cs
@@ -1,5 +1,6 @@
 using MongoDB.Driver;
 using Orleans.Storage;
+using Orleans.Providers.MongoDB.StorageProviders.Serializers;
 
 namespace Aevatar.EventSourcing.MongoDB.Options;
 
@@ -7,7 +8,15 @@ public class MongoDbStorageOptions : IStorageProviderSerializerOptions
 {
     public int InitStage { get; set; } = ServiceLifecycleStage.ApplicationServices;
 
+    /// <summary>
+    /// This is not in use, it is only for compatibility
+    /// </summary>
     public IGrainStorageSerializer GrainStorageSerializer { get; set; } = null!;
+
+    /// <summary>
+    /// The serializer to use for the grain state.
+    /// </summary>
+    public IGrainStateSerializer GrainStateSerializer { get; set; } = null!;
 
     [Redact] public MongoClientSettings ClientSettings { get; set; } = null!;
 

--- a/src/Aevatar.EventSourcing.MongoDB/Serializers/BsonGrainSerializer.cs
+++ b/src/Aevatar.EventSourcing.MongoDB/Serializers/BsonGrainSerializer.cs
@@ -1,0 +1,47 @@
+using System;
+using MongoDB.Bson;
+using MongoDB.Bson.IO;
+using MongoDB.Bson.Serialization;
+using Orleans;
+using Orleans.Providers.MongoDB.StorageProviders.Serializers;
+using Orleans.Runtime;
+
+namespace Aevatar.EventSourcing.MongoDB.Serializers;
+
+/// <summary>
+/// Grain storage serializer that uses MongoDB BSON serialization
+/// </summary>
+public class BsonGrainSerializer : IGrainStateSerializer
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BsonGrainSerializer"/> class.
+    /// </summary>
+    public BsonGrainSerializer()
+    {
+        // Register serializers for Orleans specific types
+        BsonSerializer.TryRegisterSerializer(new GrainTypeBsonSerializer());
+        BsonSerializer.TryRegisterSerializer(new IdSpanBsonSerializer());
+    }
+
+    /// <summary>
+    /// Deserializes the provided value to the specified type
+    /// </summary>
+    /// <typeparam name="T">Type to deserialize to</typeparam>
+    /// <param name="value">BSON value to deserialize</param>
+    /// <returns>Deserialized object</returns>
+    public T Deserialize<T>(BsonValue value)
+    {       
+        return BsonSerializer.Deserialize<T>(value.AsBsonDocument);
+    }
+
+    /// <summary>
+    /// Serializes an object to BSON format
+    /// </summary>
+    /// <typeparam name="T">Type of object to serialize</typeparam>
+    /// <param name="state">Object to serialize</param>
+    /// <returns>BSON representation of the object</returns>
+    public BsonValue Serialize<T>(T state)
+    {
+        return state.ToBsonDocument();
+    }
+} 

--- a/test/Aevatar.EventSourcing.MongoDB.Tests/BsonGrainSerializerTests.cs
+++ b/test/Aevatar.EventSourcing.MongoDB.Tests/BsonGrainSerializerTests.cs
@@ -1,0 +1,273 @@
+using System;
+using System.Collections.Generic;
+using Aevatar.EventSourcing.MongoDB.Serializers;
+using MongoDB.Bson;
+using Orleans.Storage;
+using Shouldly;
+using Xunit;
+
+namespace Aevatar.EventSourcing.MongoDB.Tests;
+
+/// <summary>
+/// Tests for BsonGrainSerializer to verify correct serialization/deserialization
+/// </summary>
+public class BsonGrainSerializerTests
+{
+    private readonly BsonGrainSerializer _serializer;
+
+    public BsonGrainSerializerTests()
+    {
+        _serializer = new BsonGrainSerializer();
+    }
+
+    [Fact]
+    public void Serialize_Deserialize_SimpleClass_Works()
+    {
+        // Arrange
+        // Test data: Simple class with basic properties - ID: 42, Name: "Test Name"
+        var testObject = new TestClass
+        {
+            Id = 42,
+            Name = "Test Name",
+            CreatedAt = new DateTime(2023, 1, 1, 12, 0, 0, DateTimeKind.Utc)
+        };
+
+        // Act
+        BsonValue serialized = _serializer.Serialize(testObject);
+        var deserialized = _serializer.Deserialize<TestClass>(serialized);
+
+        // Assert
+        Assert.NotNull(deserialized);
+        Assert.Equal(testObject.Id, deserialized.Id);
+        Assert.Equal(testObject.Name, deserialized.Name);
+        Assert.Equal(testObject.CreatedAt, deserialized.CreatedAt);
+    }
+
+    [Fact]
+    public void Serialize_Deserialize_ComplexClass_Works()
+    {
+        // Arrange
+        // Test data: Complex class with nested objects and collections
+        var testObject = new ComplexTestClass
+        {
+            Id = Guid.Parse("7f9c2742-5df1-42fb-96f9-7c6d5e0a2de4"),
+            Name = "Complex Test",
+            Items = new List<string> { "Item1", "Item2", "Item3" },
+            NestedObject = new TestClass
+            {
+                Id = 99,
+                Name = "Nested Object",
+                CreatedAt = new DateTime(2023, 2, 15, 10, 30, 0, DateTimeKind.Utc)
+            },
+            Properties = new Dictionary<string, object>
+            {
+                { "IntProp", 42 },
+                { "StringProp", "Value" },
+                { "BoolProp", true }
+            }
+        };
+
+        // Act
+        BsonValue serialized = _serializer.Serialize(testObject);
+        var deserialized = _serializer.Deserialize<ComplexTestClass>(serialized);
+
+        // Assert
+        Assert.NotNull(deserialized);
+        Assert.Equal(testObject.Id, deserialized.Id);
+        Assert.Equal(testObject.Name, deserialized.Name);
+        Assert.Equal(testObject.Items.Count, deserialized.Items.Count);
+        
+        // Check nested object
+        Assert.NotNull(deserialized.NestedObject);
+        Assert.Equal(testObject.NestedObject.Id, deserialized.NestedObject.Id);
+        Assert.Equal(testObject.NestedObject.Name, deserialized.NestedObject.Name);
+        
+        // Check dictionary
+        Assert.NotNull(deserialized.Properties);
+        Assert.Equal(testObject.Properties.Count, deserialized.Properties.Count);
+        Assert.Equal(42, deserialized.Properties["IntProp"]);
+        Assert.Equal("Value", deserialized.Properties["StringProp"]);
+        Assert.Equal(true, deserialized.Properties["BoolProp"]);
+    }
+
+    [Fact]
+    public void Serialize_Deserialize_EmptyObject_Works()
+    {
+        // Test data: Empty object with default values
+        
+        // Create an empty object
+        var emptyObject = new TestClass();
+        
+        // Act
+        BsonValue serialized = _serializer.Serialize(emptyObject);
+        var deserialized = _serializer.Deserialize<TestClass>(serialized);
+        
+        // Assert - empty object should be properly deserialized
+        Assert.NotNull(deserialized);
+        Assert.Equal(0, deserialized.Id);
+        Assert.Equal(string.Empty, deserialized.Name);
+        Assert.Equal(default, deserialized.CreatedAt);
+    }
+
+    [Fact]
+    public void SerializeDeserialize_SimpleObject_WorksCorrectly()
+    {
+        // Arrange
+        var serializer = new BsonGrainSerializer();
+        var testObj = new TestClass
+        {
+            StringProp = "Test String",
+            IntProp = 42,
+            BoolProp = true
+        };
+
+        // Act
+        var serialized = serializer.Serialize(testObj);
+        var deserialized = serializer.Deserialize<TestClass>(serialized);
+
+        // Assert
+        deserialized.ShouldNotBeNull();
+        deserialized.StringProp.ShouldBe(testObj.StringProp);
+        deserialized.IntProp.ShouldBe(testObj.IntProp);
+        deserialized.BoolProp.ShouldBe(testObj.BoolProp);
+    }
+
+    [Fact]
+    public void Deserialize_FullDocument_ThrowsException_WhenPassedDirectly()
+    {
+        // Arrange
+        var serializer = new BsonGrainSerializer();
+        
+        // Create a document similar to what would be stored in MongoDB
+        var document = new BsonDocument
+        {
+            ["GrainId"] = "TestGrain/123",
+            ["Version"] = 1,
+            ["data"] = new BsonDocument
+            {
+                ["StringProp"] = "Test String",
+                ["IntProp"] = 42,
+                ["BoolProp"] = true
+            }
+        };
+
+        // Act & Assert
+        // This should throw an exception since we're trying to deserialize the full document
+        // instead of just the "data" part
+        Should.Throw<InvalidOperationException>(() => serializer.Deserialize<TestClass>(document));
+    }
+
+    [Fact]
+    public void Deserialize_DataField_WorksCorrectly()
+    {
+        // Arrange
+        var serializer = new BsonGrainSerializer();
+        
+        // Create just the data field as would be extracted from document
+        var dataField = new BsonDocument
+        {
+            ["StringProp"] = "Test String",
+            ["IntProp"] = 42,
+            ["BoolProp"] = true
+        };
+
+        // Act
+        var deserialized = serializer.Deserialize<TestClass>(dataField);
+
+        // Assert
+        deserialized.ShouldNotBeNull();
+        deserialized.StringProp.ShouldBe("Test String");
+        deserialized.IntProp.ShouldBe(42);
+        deserialized.BoolProp.ShouldBe(true);
+    }
+
+    [Fact]
+    public void Deserialize_BsonDocumentWithDataField_SimulatesMongoDbStorage()
+    {
+        // Arrange - This test specifically tests how MongoDbLogConsistentStorage deserializes
+        var serializer = new BsonGrainSerializer();
+        
+        // Create a document with the same structure as what's stored/retrieved in MongoDB
+        var document = new BsonDocument
+        {
+            ["GrainId"] = "TestGrain/123",
+            ["Version"] = 1,
+            ["data"] = new BsonDocument
+            {
+                ["StringProp"] = "Test String",
+                ["IntProp"] = 42,
+                ["BoolProp"] = true
+            }
+        };
+
+        // Act - Simulate what happens in MongoDbLogConsistentStorage.ReadAsync
+        // First we get the document from MongoDB
+        // Then we should extract the "data" field
+        var dataField = document["data"];
+        
+        // Then deserialize just that field
+        var deserialized = serializer.Deserialize<TestClass>(dataField);
+
+        // Assert
+        deserialized.ShouldNotBeNull();
+        deserialized.StringProp.ShouldBe("Test String");
+        deserialized.IntProp.ShouldBe(42);
+        deserialized.BoolProp.ShouldBe(true);
+    }
+
+    [Fact]
+    public void MongoDbDocumentStructure_VerifyDataExtractionAndParsing()
+    {
+        // This test simulates the MongoDB document structure and verifies that
+        // extracting and deserializing the 'data' field works as expected
+        
+        // Arrange - create a document that matches MongoDB structure
+        var document = new BsonDocument
+        {
+            { "GrainId", "test/123" },
+            { "Version", 42 },
+            { "data", new BsonDocument
+                {
+                    { "StringProp", "Test String" },
+                    { "IntProp", 42 },
+                    { "BoolProp", true }
+                }
+            }
+        };
+        
+        var serializer = new BsonGrainSerializer();
+        
+        // Act & Assert - Direct deserialization of whole document should fail
+        var exception = Assert.Throws<InvalidOperationException>(() => 
+            serializer.Deserialize<TestClass>(document));
+        
+        // Now extract just the data field and deserialize - this should work
+        var dataField = document["data"];
+        var result = serializer.Deserialize<TestClass>(dataField);
+        
+        // Verify the deserialized object has the correct properties
+        Assert.NotNull(result);
+        Assert.Equal("Test String", result.StringProp);
+        Assert.Equal(42, result.IntProp);
+        Assert.Equal(true, result.BoolProp);
+    }
+
+    private class TestClass
+    {
+        public int Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+        public DateTime CreatedAt { get; set; }
+        public string StringProp { get; set; } = string.Empty;
+        public int IntProp { get; set; }
+        public bool BoolProp { get; set; }
+    }
+
+    private class ComplexTestClass
+    {
+        public Guid Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+        public List<string> Items { get; set; } = new();
+        public TestClass NestedObject { get; set; } = new();
+        public Dictionary<string, object> Properties { get; set; } = new();
+    }
+} 


### PR DESCRIPTION
### Summary 
- Refactor existing bson serializer following serializer configuration framework in Orleans.Provider.Mongodb
- Add support to utilise other serializer that Orleans.Provider.Mongodb supports to serialize Agent State such as BinaryGrainStateSerializer
- Add unit tests for bson serializer
- modify existing unit tests

### E2E Test
- Bson Format
<img width="1123" alt="Screenshot 2025-05-19 at 11 44 57" src="https://github.com/user-attachments/assets/2d18e931-183a-44fd-a3a7-7a143e947eba" />
<img width="1108" alt="Screenshot 2025-05-19 at 11 44 29" src="https://github.com/user-attachments/assets/5f0e515d-1cca-4f9b-999b-43a27577f48b" />

- Binary Format
<img width="1102" alt="Screenshot 2025-05-19 at 11 49 13" src="https://github.com/user-attachments/assets/c4bfc407-aeb7-43ff-8061-645bb3803edd" />
<img width="1129" alt="Screenshot 2025-05-19 at 11 49 22" src="https://github.com/user-attachments/assets/f5bf61d3-4141-4aaa-9763-49c7fb1ea474" />
- Test Event Handle using Kafka Stream
<img width="628" alt="Screenshot 2025-05-19 at 11 45 41" src="https://github.com/user-attachments/assets/fa8ca59b-cefd-4f97-a90f-02480391bb78" />

- Binary PubSub
<img width="1110" alt="Screenshot 2025-05-19 at 11 59 24" src="https://github.com/user-attachments/assets/b39e1374-e539-407f-9cc6-d87b388bab81" />


### Unit Test
<img width="861" alt="Screenshot 2025-05-18 at 01 01 09" src="https://github.com/user-attachments/assets/eab4c5eb-657b-46ab-ac64-a7415c9d00eb" />

